### PR TITLE
Extract character set directives to separate file.

### DIFF
--- a/general/tables/wincharset.asm
+++ b/general/tables/wincharset.asm
@@ -1,0 +1,12 @@
+	charset	'A', 'Z', 1
+	charset	'a', 'z', 57
+	charset '0', '9', 27
+	charset ' ', 0
+	charset	'-', $31
+	charset	'!', $32
+	charset	'?', $33
+	charset	':', $34
+	charset	'.', $53
+	charset $27, $54
+	charset	',', $55
+	charset	'·', $56

--- a/script/charset.asm
+++ b/script/charset.asm
@@ -5,11 +5,11 @@
 	charset '.', $35
 	charset $27, $36
 	charset ',', $37
-	charset 'Â·', $38
+	charset '·', $38
 	charset ':', $39
 	charset '!', $3A
 	charset '?', $3B
 	charset '-', $3C
-	charset 'Â«', $3D
-	charset 'Â»', $3E
+	charset '«', $3D
+	charset '»', $3E
 	charset '%', $3F


### PR DESCRIPTION
Instead of repeating charset directives everywhere in ps4.asm, extracted out the character set to a separate file.

script/charset.asm is the dialogue font charset.
general/tables/wincharset.asm is the window font charset.

Also fixed an oversight where the "Cannot flee!" window width was hardcoded (instead of using the constant) in one location, so editing the constant would yield rendering errors.
