### PR TITLE
Support for building with uncompressed dialogues - fixed

### DIFF
--- a/linux_build/build.sh
+++ b/linux_build/build.sh
@@ -8,6 +8,7 @@ usage="USAGE: ${this} <assembly file> <output> [output] [... [outputN]]
        ${this} --help"
 
 fixheader="`dirname $0`/fixheader.py"
+ips="`dirname $0`/lipx.py"
 
 help="$this for disassembled SEGA Mega Drive / Genesis Phantasy Star games.
 Version ${version}
@@ -132,8 +133,10 @@ create_bdelta() {
 
 # IPS is a common format too. romhacking.net users might want to use this.
 create_ips() {
-    warn "ips patches not implemented yet."
-    errexit "If you know a ips patch creation cli utility for Linux, please post an issue at:\nhttps://github.com/Zuccace/mdps-asm-builder/issues"
+    check_dep "${ips}" die && "$ips" -c "$1" "$2" || warn "ips failed."
+    mv "$2.ips" "$3"
+#    warn "ips patches not implemented yet."
+#    errexit "If you know a ips patch creation cli utility for Linux, please post an issue at:\nhttps://github.com/Zuccace/mdps-asm-builder/issues"
 }
 
 ### Go trough CLI switches.

--- a/linux_build/lipx.py
+++ b/linux_build/lipx.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+
+import collections
+import os
+import struct
+import sys
+
+VERSION = '1.1'
+_ntuple_diskusage = collections.namedtuple('usage', 'total used free')
+
+
+def disk_usage(path):
+    st = os.statvfs(path)
+    free = st.f_bavail * st.f_frsize
+    total = st.f_blocks * st.f_frsize
+    used = (st.f_blocks - st.f_bfree) * st.f_frsize
+
+    return _ntuple_diskusage(total, used, free)
+
+
+def usage():
+    print('\nLipx v' + VERSION + ' - Linux IPS tool\n\n' +
+           'Usage:\n' +
+           '    lipx.py -a originalFile patchFile\n' +
+           '    >[Apply a patch]\n\n' +
+           '    lipx.py -ab originalFile patchFile\n' +
+           '    >[Create a copy and apply the patch - original is untouched]\n\n' +
+           '    lipx.py -c originalFile modifiedFile\n' +
+           '    >[Create an IPS patch]\n')
+
+    sys.exit(1)
+
+
+# Helper function to get an integer from a bytearray (Big endian)
+def get_uint16(data, index):
+    return int((data[index] << 8) | data[index + 1])
+
+
+# Helper function to get an integer from a bytearray (Big endian)
+def get_uint24(data, index):
+    return int((data[index] << 16) | (data[index + 1] << 8) | data[index + 2])
+
+
+class IPS(object):
+    def __init__(self, cmd, original_file, modified_file, patch_file):
+        # 16MB Max size of an IPS file - 3byte int
+        self.FILE_LIMIT = 0x1000000
+
+        # Max size of an individual record - 2 byte int
+        self.RECORD_LIMIT = 0xFFFF
+
+        # IPS file header 'PATCH'
+        self.PATCH_ASCII = b"\x50\x41\x54\x43\x48"
+
+        # IPS file footer 'EOF'
+        self.EOF_ASCII = b"\x45\x4f\x46"
+
+        # Lipx Command
+        self.cmd = cmd
+
+        # Unmodified ROM File
+        self.original_file = original_file
+
+        # Modified ROM File
+        self.modified_file = modified_file
+
+        # IPS Patch File
+        self.patch_file = patch_file
+
+        # Accounting variables
+        self.curr_offset = 0
+        self.record_count = 0
+        self.patch_size = 0
+
+    def __call__(self):
+        ret = False
+
+        print('### Lipx v' + VERSION + ' - Linux IPS Tool ###\n')
+
+        self._setup_files()
+
+        if self.cmd == '-c':
+            ret = self.create_ips()
+        elif self.cmd == '-a' or self.cmd == '-ab':
+            ret = self.apply_ips()
+
+        if not ret:
+            print('> Error - __call__ error!')
+            sys.exit(1)
+
+        return True
+
+    def __check_disk_space(self, file_to_check):
+        directory = os.path.dirname(os.path.abspath(file_to_check))
+
+        if directory == '':
+            directory = '.'
+
+        if disk_usage(directory).free <= self.FILE_LIMIT:
+            return False
+
+        return True
+
+    def _setup_files(self):
+        if not self.__check_disk_space(self.patch_file):
+            print('> Not enough space on this disk!\n')
+            sys.exit(1)
+
+        if self.cmd == '-ab':
+            if not self.__check_disk_space(self.original_file):
+                print('> Not enough space on this disk!\n')
+                sys.exit(1)
+
+        # File object containing the original (base) ROM data
+        try:
+            self.original_data = open(self.original_file, 'rb').read()
+        except:
+            print("> Cannot read %s" % self.original_file + '.\n')
+            sys.exit(1)
+
+        # File object containing the modified ROM data (To create IPS patch)
+        if self.cmd != '-a' and self.cmd != '-ab':
+            try:
+                self.modified_data = open(self.modified_file, 'rb').read()
+            except:
+                print("> Cannot read %s" % self.modified_file + '.\n')
+                sys.exit(1)
+
+        # File object containing the IPS patch
+        try:
+            if self.cmd == '-a' or self.cmd == '-ab':
+                self.patch_file_obj = bytearray(open(self.patch_file, 'rb').read())
+            else:
+                self.patch_file_obj = open(self.patch_file, 'wb')
+        except:
+            print("> Cannot read %s" % self.patch_file + '.\n')
+            sys.exit(1)
+
+        if self.cmd != '-a' and self.cmd != '-ab':
+            # The IPS file format has a size limit of 16MB
+            if len(self.modified_data) > self.FILE_LIMIT:
+                print('File is too large! ( Max 16MB )\nThe patch could be broken!')
+
+        return True
+
+    def write_record(self, record_data, overide_size=0):
+        """
+        Method that takes relevant data and write an IPS record (non-RLE encoded)
+
+        Format looks like (all integers in BIG endian):
+        [OFFSET into file : 3bytes][SIZE of record : 2bytes][BYTES : SIZEbytes]
+        """
+
+        # Encode record's absolute offset into the original ROM,
+        # (IPS file format uses big endian 3-byte int, hence a truncated long, yuck!)
+        self.patch_file_obj.write(struct.pack(">L", self.curr_offset)[1:])
+
+        # Encode size of record
+        if not overide_size:
+            self.patch_file_obj.write(struct.pack(">H", len(record_data)))
+        else:
+            self.patch_file_obj.write(struct.pack(">H", overide_size))
+
+        # Write the data
+        self.patch_file_obj.write(record_data)
+
+        # Do some accounting
+        self.record_count += 1
+        self.patch_size += len(record_data) + 5
+
+    def apply_ips(self):
+        a = 5
+        file_to_patch = self.original_file
+
+        if self.cmd == '-ab':
+            try:
+                org_file_cont = bytearray(open(file_to_patch, 'rb').read())
+                open('Patched_'+file_to_patch, 'wb').write(org_file_cont)
+            except:
+                print('> Error - Cannot create Patched_%s' % file_to_patch)
+                sys.exit(1)
+
+            file_to_patch = 'Patched_'+self.original_file
+
+        patched_file = bytearray(open(file_to_patch, 'rb').read())
+
+        while a < len(self.patch_file_obj) - 3:
+            # Get offset
+            offset = get_uint24(self.patch_file_obj, a)
+            a += 3
+
+            # Get packet size
+            size = get_uint16(self.patch_file_obj, a)
+            a += 2
+
+            if size == 0:
+                # Get RLE repeat count
+                rle_size = get_uint16(self.patch_file_obj, a)
+                a += 2
+
+                # Get repeat byte
+                repeat = self.patch_file_obj[a]
+                a += 1
+
+                for x in range(rle_size):
+                    try:
+                        patched_file[offset + x] = repeat
+                    except:
+                        print('> Error - Unable to parse the patch!')
+                        sys.exit(1)
+            else:
+                # Normal packet, copy from patch to file
+                for x in range(size):
+                    try:
+                        patched_file[offset + x] = self.patch_file_obj[a]
+                        a += 1
+                    except:
+                        print('> Error - Unable to parse the patch!')
+                        sys.exit(1)
+
+        try:
+            # Write modified data
+            open(file_to_patch, 'wb').write(patched_file)
+        except:
+            print('> Error - Cannot write to file!')
+            sys.exit(1)
+
+        print('> Success - Patch applied to %s' % file_to_patch)
+
+        return True
+
+    def create_ips(self):
+        record_begun = False
+        record = bytearray()
+        original_data_len = len(self.original_data)
+
+        # IPS file header
+        self.patch_file_obj.write(self.PATCH_ASCII)
+        self.patch_size += len(self.PATCH_ASCII)
+
+        # Write the IPS record(s).
+        # Format looks like (all integers in BIG endian):
+        # [OFFSET into file : 3bytes][SIZE of record : 2bytes][BYTES : SIZEbytes]
+
+        # Diff bytes between the new ROM and the base ROM, 1 byte at a time
+        for pos in range(len(self.modified_data)):
+            if not record_begun:
+
+                if original_data_len <= pos or self.modified_data[pos] != self.original_data[pos]:
+                    record_begun = True
+                    record = bytearray()
+
+                    # From http://romhack.wikia.com/wiki/IPS in 'Caveats' section:
+                    #
+                    # The number 0x454f46 looks like "EOF" in ASCII, which is why a patch record must never begin at
+                    # offset 0x454f46. If your program generates a patch record at offset 0x454f46, then you have a bug,
+                    # because IPS patchers will read the "EOF". One possible workaround is to start at offset 0x454f45
+                    # and include the extra byte in the patch.
+                    #
+                    # If a patch provides multiple values for the same byte in the patched file, then the IPS patcher
+                    # may use any of these overlapped values. Also, if the patch extends the size of the patched file,
+                    # but does not provide values for all bytes in the extended area, then the IPS patcher may fill the
+                    # gaps with any values. A better IPS file provides no such overlapped values and no such gaps,
+                    # though this is not a requirement of the IPS format.
+                    if pos == self.EOF_ASCII:
+                        record.append(self.modified_data[pos - 1])
+
+                    # Add the byte from the new ROM at address 'a' to the record
+                    record.append(self.modified_data[pos])
+
+                    # Save the absolute offset for this record
+                    self.curr_offset = pos
+
+                    # Corner case - should never hit for real ROMs
+                    # If we're at the last address, close the record and write to the patch file
+                    if pos == len(self.modified_data) - 1:
+                        record_begun = False
+                        self.write_record(record, overide_size=0x01)
+            else:
+                # Records have a max size of 0xFFFF as the size header is a short
+                # Check our current position and if we at the max size end the record and start a new one
+                if len(record) == self.RECORD_LIMIT - 1:
+                    print("Truncating overlong record: %s %s" % (len(record), hex(len(record))))
+
+                    record_begun = False
+                    record.append(self.modified_data[pos])
+                    self.write_record(record)
+
+                # Append diff data to the record
+                elif (original_data_len <= pos or
+                              self.modified_data[pos] != self.original_data[pos]) and pos != len(self.modified_data) - 1:
+                    # Continue Record
+                    record.append(self.modified_data[pos])
+
+                # END OF RECORD
+                # If we're at the last address of the new ROM, the bytes at the address are identical in both ROMs,
+                # or the base ROM  is longer than the address we are at in the modified ROM close the record
+                else:
+                    record_begun = False
+                    self.write_record(record)
+
+        # Add the footer to the IPS file and flush the data to disk & close entire IPS file
+        self.patch_file_obj.write(self.EOF_ASCII)
+        self.patch_size += len(self.EOF_ASCII)
+        self.patch_file_obj.close()
+
+        print("> Success - Patch file: %s" % self.patch_file)
+
+        return True
+
+
+if __name__ == '__main__':
+    arg_len = len(sys.argv)
+
+    if arg_len > 1:
+        if sys.argv[1] == '-a' or sys.argv[1] == '-ab':
+            if arg_len != 4:
+                usage()
+
+            ips = IPS(sys.argv[1], sys.argv[2], '', sys.argv[3])
+
+            ips()
+        elif sys.argv[1] == '-c':
+            if arg_len != 4:
+                usage()
+
+            patch_file_name = sys.argv[3]+'.ips'
+            ips = IPS(sys.argv[1], sys.argv[2], sys.argv[3], patch_file_name)
+
+            ips()
+        else:
+            usage()
+    else:
+        usage()
+
+    sys.exit(0)
+

--- a/ps4.constants.asm
+++ b/ps4.constants.asm
@@ -2185,7 +2185,11 @@ Saved_Sound_Index = ramaddr($FFFFECEC)
 Battle_Type = ramaddr($FFFFECEE)	; 0 = Profound Darkness battle; 1 = event (or boss) battle; 2 = random battle
 Mota_Battle_BG_Index = ramaddr($FFFFECEF)	; Motavia (outside) has different backgrounds depending on the tile you're standing on
 
-Saved_Dialogue_Addr = ramaddr($FFFFECF0)	; word
+	if dialogue_uncompressed = 1
+Saved_Dialogue_Addr = ramaddr($FFFFED64)	; dword if dlg uncompressed since we must point at correct ROM address AND there's more than 64 kb of dialogue... Note that this is used by a macro so this is mostly for documenting
+	else
+Saved_Dialogue_Addr = ramaddr($FFFFECF0)	; word if dlg compresssed, since it's in RAM it just gets sign-extended
+	endif
 Map_Dialogue_Trees_Addr = ramaddr($FFFFECF8)
 
 Event_Battle_Index = ramaddr($FFFFECFC)

--- a/ps4.constants.asm
+++ b/ps4.constants.asm
@@ -1969,11 +1969,11 @@ RAM_Start = ramaddr($FFFF0000)
 Battle_Palette_Objects = ramaddr($FFFF2A90)
 Dialogue_Trees = ramaddr($FFFF3000)
 
-; If your dialogue is too large, you can gain around 1000 bytes by
+; If your dialogue is too large, you can gain $1000 bytes by
 ; commenting the two lines above and uncommenting the two below.
-; Note that this is still untested.
-;Battle_Palette_Objects = ramaddr($FFFF2000)
-;Dialogue_Trees = ramaddr($FFFF2A90)
+; This is not fully tested yet but appears to work.
+;Dialogue_Trees = ramaddr($FFFF2000)
+;Battle_Palette_Objects = ramaddr($FFFF2A90)
 
 
 Battle_Routine = ramaddr($FFFF4100)

--- a/ps4.constants.asm
+++ b/ps4.constants.asm
@@ -2203,6 +2203,9 @@ Saved_Char_ID_Mem_3 = ramaddr($FFFFED56)
 Saved_Char_ID_Mem_4 = ramaddr($FFFFED57)
 Saved_Char_ID_Mem_5 = ramaddr($FFFFED58)
 
+; this is only used if uncompressed_dialogs is true
+Current_Dialogue_Tree = ramaddr($FFFFED60)
+
 TextCounter = ramaddr($FFFFED90)		; Used to count scrolling intro text or ending credits frame count
 FadeControl = ramaddr($FFFFED95)		; Used to count palette fade in/out frames
 CredText_A = ramaddr($FFFFED96)			; Additional flags for palette fade in/out

--- a/ps4.macrosetup.asm
+++ b/ps4.macrosetup.asm
@@ -119,3 +119,28 @@ _tst	macro
 		insn1op tst.ATTRIBUTE, ALLARGS
 	endm
 
+; when managing dialogues compressed vs uncompressed,
+; we must modify some code to store the saved dialogue
+; in a different location because it needs to be a
+; 24-bit value, since in ROM the dialogue size is > 64KB
+; (and also it'S not in RAM so we can't just sign-extend)
+pushdlg		macro
+	if dialogue_uncompressed = 1
+		move.l  a0, (Saved_Dialogue_Addr).w
+	else
+		move.w	a0, (Saved_Dialogue_Addr).w
+	endif
+	endm
+
+popdlg		macro
+	if dialogue_uncompressed = 1
+		move.l  (Saved_Dialogue_Addr).w, d0
+	else
+		moveq	#-1, d0
+		move.w	(Saved_Dialogue_Addr).w, d0
+	endif
+	movea.l d0, a0
+	endm
+
+
+

--- a/ps4.macrosetup.asm
+++ b/ps4.macrosetup.asm
@@ -118,3 +118,4 @@ _clr	macro
 _tst	macro
 		insn1op tst.ATTRIBUTE, ALLARGS
 	endm
+

--- a/ps4.options.asm
+++ b/ps4.options.asm
@@ -1,0 +1,5 @@
+
+bugfixes = 0			; if 1, include bug fixes
+optional_fixes  = 0		; if 1, include optional (larger) fixes
+restore_unused_enemies = 0	; if 1, Acacia and Shadow Mirage will show up
+dialogue_uncompressed = 0	; if 1, dialogue is stored uncompressed

--- a/script/compress_script.py
+++ b/script/compress_script.py
@@ -28,9 +28,7 @@ class IgnoreDcProcessor:
 		return line
 
 	def process(self, m, linenum):
-		global debug
-		if debug:
-			print(m)
+		pass
 
 DC_W_DIRECTIVE = re.compile(r"^\s+dc\.w\s+((\$[A-Fa-f0-9]{4})|(\d+))\s*(;.*)?$")
 class DcWProcessor(IgnoreDcProcessor):
@@ -236,9 +234,9 @@ class Processor:
 		if m:
 			var, val = m.group(1), m.group(2)
 			if val == self.symbols.get(var, None):
-				return look_for_else
+				return self.look_for_else
 			else:
-				return look_for_else_skip
+				return self.look_for_else_skip
 		self.process_non_controlflow(line)
 		return self.normal
 		
@@ -272,7 +270,7 @@ class Processor:
 		if m:
 			return self.normal
 		self.process_non_controlflow(line)
-		return look_for_endif
+		return self.look_for_endif
 			
 	def process_non_controlflow(self, line):
 		m = ASSIGN_DIRECTIVE.match(line)

--- a/script/compress_script.py
+++ b/script/compress_script.py
@@ -14,22 +14,286 @@ MAX_TEXT_SIZE = MAX_TEXT_ADDRESS - Dialogue_Trees_ADDRESS
 # alternatively, if you're not 100% sure, max length in US script is 7220 bytes
 #MAX_TEXT_SIZE = 7220
 
+def decodenum(s):
+	if s[0] == '$':
+		return int(s[1:], 16)
+	else:
+		return int(s)
+
+class IgnoreDcProcessor:
+	def __init__(self, fname):
+		self.fname = fname
+		
+	def matches(self, line):
+		return line
+
+	def process(self, m, linenum):
+		global debug
+		if debug:
+			print(m)
+
+DC_W_DIRECTIVE = re.compile(r"^\s+dc\.w\s+((\$[A-Fa-f0-9]{4})|(\d+))\s*(;.*)?$")
+class DcWProcessor(IgnoreDcProcessor):
+
+	def __init__(self, fname, out):
+		super().__init__(fname)
+		self.out = out
+		
+	def matches(self, line):
+		self.m = DC_W_DIRECTIVE.match(line)
+		return self.m
+		
+	def process(self, m, linenum):
+		s = m.group(1)
+		decoded = decodenum(s)
+		out.write(bytes([(decoded&0xFF00)>>8, decoded&0xFF]))
+		
+DC_DIRECTIVE = re.compile(r"^\s+dc\.b\s+(.*)$")
+hexdigits = set("ABCDEFabcdef0123456789")
+class DcBProcessor(IgnoreDcProcessor):
+	
+	def __init__(self, fname, out, charset, symbols):
+		super().__init__(fname)
+		self.out = out
+		self.charset = charset
+		self.buf = []
+		self.state = self.scanning
+		
+	def matches(self, line):
+		self.m = DC_DIRECTIVE.match(line)
+		return self.m
+	
+	def process(self, m, linenum):
+		self.state = self.scanning
+		self.buf.clear()
+		for ch in m.group(1):
+			self.state = self.state(ch, linenum)
+		self.state(None, linenum)
+
+	def syntax_error(self, ch, linenum):
+		print("Syntax error: illegal character", ch, "file:", self.fname, "@", linenum)
+		sys.exit(-1)
+		
+	def comment(self, ch, linenum):
+		return self.comment
+
+	def hex_digit(self, ch, linenum):
+		if ch is not None and ch in hexdigits:
+			self.buf.append(ch)
+			return self.hex_digit
+		else:
+			translated = decodenum(''.join(self.buf))
+			out.write(bytes([translated]))
+			self.buf.clear()
+			return self.scanning(ch, linenum)
+		
+	def in_quote(self, ch, linenum):
+		if ch is None:
+			self.syntax_error("newline", linenum)
+		if ch == '"':
+			return self.maybe_quote_char
+		self.buf.append(ch)
+		return self.in_quote
+
+	def maybe_quote_char(self, ch, linenum):
+		if ch is not None and ch == '"':
+			self.buf.append('"')
+			return self.in_quote
+		else:
+			# translate unknown chars to space
+			self.out.write(bytes([self.charset.get(ch, self.charset.get(' ', 0)) for ch in self.buf]))
+			self.buf.clear()
+			return self.scanning(ch, linenum)
+
+	def dec_digit(self, ch, linenum):
+		if ch is not None and ch.isdigit():
+			self.buf.append(ch)
+			return self.dec_digit
+		else:
+			translated = decodenum(''.join(self.buf))
+			self.out.write(bytes([translated]))
+			self.buf.clear()
+			return self.scanning(ch, buf, linenum, out)
+			
+	def identifier(self, ch, linenum):
+		if ch is None or ch == ',' or ch.isspace():
+			sym = ''.join(self.buf)
+			val = self.symbols[sym]
+			# split in bytes
+			if val < 0xFF:
+				self.syntax_error(sym, linenum)
+				
+			self.out.write(bytes([val]))
+			return self.scanning
+		elif ch.isalnum():
+			self.buf.append(ch)
+			return self.identifier
+		else:
+			self.syntax_error(ch, linenum)
+
+	def scanning(self, ch, linenum):
+		if ch is None:
+			return
+		if ch == '$':
+			self.buf.append('$')
+			return self.hex_digit
+		if ch == ',':
+			return self.scanning
+		if ch == '"':
+			return self.in_quote
+		if ch == ';':
+			return self.comment
+		if ch.isdigit():
+			self.buf.append(ch)
+			return self.dec_digit
+		if ch.isidentifier():
+			self.buf.append(ch)
+			return self.identifier
+		if ch.isspace():
+			return self.scanning
+		self.syntax_error(ch, linenum)
+		
+class CompositeDcProcessor:
+	def __init__(self, fname, out, charset, symbols):
+		self.delegate = [DcWProcessor(fname, out),
+				 DcBProcessor(fname, out, charset, symbols),
+				 IgnoreDcProcessor(fname)]
+		self.current = None
+	
+	def matches(self, line):
+		self.current = None
+		for d in self.delegate:
+			m = d.matches(line)
+			if m:
+				self.current = d
+				return m
+	
+	def process(self, m, linenum):
+		self.current.process(m, linenum)
+		self.current = None
+
 
 CHARSET_RANGE = re.compile(r"^\s+charset\s+'(.)'\s*,\s*'(.)'\s*,\s*((\$[A-Fa-f0-9][A-Fa-f0-9])|(\d+))\s*(;.*)?$")
 CHARSET_SINGLE = re.compile(r"^\s+charset\s+'(.)'\s*,\s*((\$[A-Fa-f0-9][A-Fa-f0-9])|(\d+))\s*(;.*)?$")
 CHARSET_SINGLE_NUM = re.compile(r"^\s+charset\s+(\$[A-Fa-f0-9][A-Fa-f0-9])\s*,\s*((\$[A-Za-z0-9][A-Za-z0-9])|(\d+))\s*(;.*)?$")
+class CharsetProcessor:
+	
+	def __init__(self, fname, charset, rcharset):
+		self.fname = fname
+		self.charset = charset
+		self.rcharset = rcharset
+		self.linenum = 0
+	
+	def process(self, line):
+		self.linenum += 1
+		r = CHARSET_RANGE.match(line)
+		if r:
+			base = decodenum(r.group(3))
+			for count, ch in enumerate(range(ord(r.group(1)), ord(r.group(2)) + 1)):
+				self.charset[chr(ch)] = base + count
+				self.rcharset[base+count] = chr(ch)
+			return
+			
+		single = CHARSET_SINGLE.match(line)
+		if single:
+			self.charset[single.group(1)] = decodenum(single.group(2))
+			self.rcharset[decodenum(single.group(2))] = single.group(1)
+			return
+			
+		single_num = CHARSET_SINGLE_NUM.match(line)
+		if single_num:
+			self.charset[chr(decodenum(single_num.group(1)))] = decodenum(single_num.group(2))
+			self.rcharset[decodenum(single_num.group(2))] = chr(decodenum(single_num.group(1)))
+			return
+			
+		print("Invalid charset line; file:", self.fname, "@", self.linenum, "- ignoring")
 
+
+ASSIGN_DIRECTIVE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*((\$[A-Fa-f0-9]+)|(\d+))\s*(;.*)?$")
 IF_DIRECTIVE = re.compile(r"^\s+if\s+([A-Za-z0-9_]+)\s*=\s*([0-9]+)\s*$")
 ELSE_DIRECTIVE = re.compile(r"^\s+else\s*$")
 ENDIF_DIRECTIVE = re.compile(r"^\s+endif\s*$")
-DC_DIRECTIVE = re.compile(r"^\s+dc\.b\s+(.*)$")
-DC_W_DIRECTIVE = re.compile(r"^\s+dc\.w\s+((\$[A-Fa-f0-9]{4})|(\d+))\s*(;.*)?$")
+class Processor:
+	def __init__(self, filename, symbols, dc_processor):
+		self.filename = filename
+		self.linenum = 1
+		self.state = self.normal
+		self.symbols = symbols
+		self.dc_processor = dc_processor
+		
+	def process(self, line):
+		if self.state is None:
+			return
+		self.state = self.state(line)
+		self.linenum += 1
+		
+	def check(self):
+		if self.state != self.normal:
+			abort("unterminated if", self.filename)
+	
+	def normal(self, line):
+		m = IF_DIRECTIVE.match(line)
+		if m:
+			var, val = m.group(1), m.group(2)
+			if val == self.symbols.get(var, None):
+				return look_for_else
+			else:
+				return look_for_else_skip
+		self.process_non_controlflow(line)
+		return self.normal
+		
+	def look_for_else_skip(self, line):
+		m = ELSE_DIRECTIVE.match(line)
+		if m:
+			return self.look_for_endif
+		m = ENDIF_DIRECTIVE.match(line)
+		if m:
+			return self.normal
+		return self.look_for_else_skip
+		
+	def look_for_else(self, line):
+		m = ELSE_DIRECTIVE.match(line)
+		if m:
+			return self.look_for_endif_skip
+		m = ENDIF_DIRECTIVE.match(line)
+		if m:
+			return self.normal
+		self.process_non_controlflow(line)
+		return self.look_for_else
+			
+	def look_for_endif_skip(self, line):
+		m = ENDIF_DIRECTIVE.match(line)
+		if m:
+			return self.normal
+		return self.look_for_endif_skip
 
-charset = {}
-rcharset = {0xff: '\n-----\n', 0xfc: '\n', 0xfd: '\nVV\n'}
+	def look_for_endif(self, line):
+		m = ENDIF_DIRECTIVE.match(line)
+		if m:
+			return self.normal
+		self.process_non_controlflow(line)
+		return look_for_endif
+			
+	def process_non_controlflow(self, line):
+		m = ASSIGN_DIRECTIVE.match(line)
+		if m:
+			self.symbols[m.group(1)] = decodenum(m.group(2))
+			return
+		
+		m = self.dc_processor.matches(line)
+		if m:
+			self.dc_processor.process(m, self.linenum)
+			
+	def abort(self, s, filename):
+		print(s, "file:", self.fname, "@", self.linenum)
+		sys.exit(-1)
 
-symbols = [a for a in sys.argv[1:] if '=' in a]
-symbols = {arg: val for arg, val in map(lambda s: s.split('='), symbols)}
+basedir = pathlib.Path(sys.argv[0]).resolve().parent
+print("Working directory:", basedir)
+
+
+cmd_symbols = [a for a in sys.argv[1:] if '=' in a]
+cmd_symbols = {arg: val for arg, val in map(lambda s: s.split('='), cmd_symbols)}
 remainder = set([a for a in sys.argv[1:] if '=' not in a])
 debug = False
 no_compress = False
@@ -43,39 +307,32 @@ if "--no-compress" in remainder:
 	
 remainder = [pathlib.Path(f) for f in remainder]
 
+symbols = {}
+
+# load symbols from ps4.options.asm in directory one above
+fname = basedir.parent / "ps4.options.asm"
+if fname.exists():
+	with open(fname, "rt", encoding="iso-8859-1") as f:
+		processor = Processor(fname, symbols, IgnoreDcProcessor(fname))
+		for line in f:
+			line = line.rstrip()
+			processor.process(line)
+
+# override with command line settings
+symbols.update(cmd_symbols)
+
 print("Processing using symbols:", symbols)
 
-basedir = pathlib.Path(sys.argv[0]).resolve().parent
-print("Working directory:", basedir)
+charset = {}
+rcharset = {0xff: '\n-----\n', 0xfc: '\n', 0xfd: '\nVV\n'}
 
-def decodenum(s):
-	if s[0] == '$':
-		return int(s[1:], 16)
-	else:
-		return int(s)
-
-with open(basedir / "charset.asm", "rt", encoding="iso-8859-1") as f:
+fname = basedir / "charset.asm"
+with open(fname, "rt", encoding="iso-8859-1") as f:
+	charset_processor = CharsetProcessor(fname, charset, rcharset)
 	for line in f:
 		line = line.rstrip()
-		r = CHARSET_RANGE.match(line)
-		if r:
-			base = decodenum(r.group(3))
-			for count, ch in enumerate(range(ord(r.group(1)), ord(r.group(2)) + 1)):
-				charset[chr(ch)] = base + count
-				rcharset[base+count] = chr(ch)
-			continue
-			
-		single = CHARSET_SINGLE.match(line)
-		if single:
-			charset[single.group(1)] = decodenum(single.group(2))
-			rcharset[decodenum(single.group(2))] = single.group(1)
-			continue
-			
-		single_num = CHARSET_SINGLE_NUM.match(line)
-		if single_num:
-			charset[chr(decodenum(single_num.group(1)))] = decodenum(single_num.group(2))
-			rcharset[decodenum(single_num.group(2))] = chr(decodenum(single_num.group(1)))
-
+		charset_processor.process(line)
+		
 print("Using charset table:")
 for char, value in charset.items():
 	if char.isprintable():
@@ -83,134 +340,6 @@ for char, value in charset.items():
 	else:
 		print('\t${0:02X}: {1:02X}'.format(ord(char[0]), value))
 
-def normal(line, linenum, out):
-	m = IF_DIRECTIVE.match(line)
-	if m:
-		var, val = m.group(1), m.group(2)
-		if val == symbols.get(var, None):
-			return look_for_else
-		else:
-			return look_for_else_skip
-	process_raw_dc(line, linenum, out)
-	return normal
-	
-def look_for_else_skip(line, linenum, out):
-	m = ELSE_DIRECTIVE.match(line)
-	if m:
-		return look_for_endif
-	m = ENDIF_DIRECTIVE.match(line)
-	if m:
-		return normal
-	return look_for_else_skip
-	
-def look_for_else(line, linenum, out):
-	m = ELSE_DIRECTIVE.match(line)
-	if m:
-		return look_for_endif_skip
-	m = ENDIF_DIRECTIVE.match(line)
-	if m:
-		return normal
-	process_raw_dc(line, linenum, out)
-	return look_for_else
-		
-def look_for_endif_skip(line, linenum, out):
-	m = ENDIF_DIRECTIVE.match(line)
-	if m:
-		return normal
-	return look_for_endif_skip
-
-def look_for_endif(line, linenum, out):
-	m = ENDIF_DIRECTIVE.match(line)
-	if m:
-		return normal
-	process_raw_dc(line, linenum, out)
-	return look_for_endif
-		
-def process_raw_dc(line, linenum, out):
-	m = DC_DIRECTIVE.match(line)
-	if m:
-		process_dc(m.group(1), linenum, out)
-		return
-	m = DC_W_DIRECTIVE.match(line)
-	if m:
-		s = m.group(1)
-		decoded = decodenum(s)
-		out.write(bytes([(decoded&0xFF00)>>8,decoded&0xFF]))
-	else:
-		#print(line)
-		pass
-
-def process_dc(dc, linenum, out):
-	state = scanning
-	buf = []
-	for ch in dc:
-		state = state(ch, buf, linenum, out)
-	state(None, buf, linenum, out)
-
-def syntax_error(ch, linenum):
-	print("Syntax error: illegal character", ch, "@", linenum)
-	sys.exit(-1)
-	
-def comment(ch, buf, linenum, out):
-	return comment
-
-hexdigits = set("ABCDEFabcdef0123456789")
-def hex_digit(ch, buf, linenum, out):
-	if ch is not None and ch in hexdigits:
-		buf.append(ch)
-		return hex_digit
-	else:
-		translated = decodenum(''.join(buf))
-		out.write(bytes([translated]))
-		buf.clear()
-		return scanning(ch, buf, linenum, out)
-	
-def in_quote(ch, buf, linenum, out):
-	if ch is None:
-		syntax_error("newline", linenum)
-	if ch == '"':
-		return maybe_quote_char
-	buf.append(ch)
-	return in_quote
-
-def maybe_quote_char(ch, buf, linenum, out):
-	if ch is not None and ch == '"':
-		buf.append('"')
-		return in_quote
-	else:
-		# translate unknown chars to space
-		out.write(bytes([charset.get(ch, charset.get(' ', 0)) for ch in buf]))
-		buf.clear()
-		return scanning(ch, buf, linenum, out)
-
-def dec_digit(ch, buf, linenum, out):
-	if ch is not None and ch.isdigit():
-		buf.append(ch)
-		return dec_digit
-	else:
-		translated = decodenum(''.join(buf))
-		out.write(bytes([translated]))
-		buf.clear()
-		return scanning(ch, buf, linenum, out)
-
-def scanning(ch, buf, linenum, out):
-	if ch is None:
-		return
-	if ch == '$':
-		buf.append('$')
-		return hex_digit
-	if ch == ',':
-		return scanning
-	if ch == '"':
-		return in_quote
-	if ch == ';':
-		return comment
-	if ch.isdigit():
-		buf.append(ch)
-		return dec_digit
-	if ch.isspace():
-		return scanning
-	syntax_error(ch, linenum)
 	
 def dump(f):
 	print(f)
@@ -225,6 +354,7 @@ def dump(f):
 
 if len(remainder) == 0:
 	remainder = basedir.glob('dialogue *.asm')
+
 for fname in remainder:
 	print("processing", fname)
 	dest = fname.with_suffix('.bin.unc')
@@ -236,16 +366,15 @@ for fname in remainder:
 	if idx != 0:
 		print("backing up", dest, "to", dest2)
 		dest.rename(dest2)
-	state = normal
 	with open(fname, "rt", encoding="iso-8859-1") as f, open(dest, "wb") as out:
-		for linenum, line in enumerate(f):
+		processor = Processor(fname, symbols, CompositeDcProcessor(fname, out, charset, symbols))
+		for line in f:
 			line = line.rstrip()
-			state = state(line, linenum, out)
+			processor.process(line)
 			if debug:
 				print(out.tell(), ':', line)
-		if state != normal:
-			print("Unterminated if in ", fname, ", aborting", sep='')
-			sys.exit(-1)
+		processor.check()
+		# todo: make that part of the processor somehow
 		if out.tell() % 2 != 0:
 			out.write(bytes([0]))
 		print("done processing", fname, "to", dest)
@@ -254,6 +383,7 @@ for fname in remainder:
 			print("You may need to relocate the decompression buffer.", file=sys.stderr, sep='')
 			print("Press enter to continue.", file=sys.stderr, sep='')
 			input()
+
 	if debug:
 		dump(dest)
 		if dest2.exists():


### PR DESCRIPTION
* Add IPS support for Linux build script.
* Refactor compress script so it could be more easily repurposed for formation data
* Move switches to ps4.options.asm instead of main ps4.asm file, as the number is growing and it's becoming a bit unwieldy (also, so the compress script can include it to read settings)
* Bake support for building uncompressed dialogues right in the main distribution, obsoleting (partially) the ps4disasm-uncomp branch. To fully obsolete it we'd need to also provide support for uncompressing formation data. That would be more complex because the formation source code depends on offset calculations from actual addresses; changing those to simple integers would help but would also be less robust. So I've tabled this for the time being.
* Extract two macros for manipulating the Saved_Dialogue_Addr memory location, since in the uncompressed case we have to turn it into a non-RAM address, so we can't just sign-extend it from #$FFFF0000 as is done by the original ROM code. However, the we still want to emit the original code when we're keeping the dialogue compressed. Thus those two macros.

Feel free to rename the macros if you feel they're not obvious enough. They stand for "push dialogue pointer to RAM" (pushdlg) and "pop dialogue pointer from RAM" (popdlg)