### PR TITLE
Fix physical damage bug when riding a vehicule

### DIFF
--- a/ps4.constants.asm
+++ b/ps4.constants.asm
@@ -56,6 +56,7 @@ skills = $62
 curr_skill_uses = $6A
 max_skill_uses = $6B
 gain_exp_flag = $7A		; byte ; flag which is set if a character participates and wins a battle at least once. After that characters start gaining experience even if they are not in the party
+physical_prop_save = $7B	; in case we use the physical_prop bugfix, we need to save the prop here so defend doesn't override the armor setting
 ; ---------------------------------------------------------------------------
 
 ; ---------------------------------------------------------------------------

--- a/ps4.constants.asm
+++ b/ps4.constants.asm
@@ -2044,6 +2044,9 @@ Chunk_Table = ramaddr($FFFF6000)	; 32x32 definitions; 32 bytes (16 words) per de
 Text_Buffer = ramaddr($FFFF7000)
 Plane_A_Buffer = ramaddr($FFFF8000)
 Plane_B_Buffer = ramaddr($FFFF9000)
+Plane_A_Buffer_DMA = $7FFFC000		; when we refer to plane buffers through DMA, value has to be divided by 2
+Plane_B_Buffer_DMA = $7FFFC800		; if you change location of those plane buffers make sure you change the
+					; _DMA values as well
 Map_Layout_FG = ramaddr($FFFFA000)
 Map_Layout_BG = ramaddr($FFFFB000)
 


### PR DESCRIPTION
When in a vehicule, the "Physical property fix" bug makes all
physical attacks do only 1 of damage. The exact reason for this
has not been investigated, but I added a check to ensure the
user is not in a vehicule before applying that new logic.