### PR TITLE
Add option for restoring removed enemies for releases outside Japan

### DIFF
--- a/ps4.options.asm
+++ b/ps4.options.asm
@@ -3,4 +3,5 @@ bugfixes = 0			; if 1, include bug fixes
 optional_fixes  = 0		; if 1, include optional (larger) fixes
 dialogue_uncompressed = 0	; if 1, dialogue is stored uncompressed
 revision = 1			; 0 = Japanese; 1 = English; 2 = European
+restored_enemy = 0		; if 1, restores enemies Acacia and Shadmirage (only needed if revision is not set to 0)
 light_sensitivity_patch = 0	; if 1, tone down flashing effects; values are taken from the Virtual Console version


### PR DESCRIPTION
Adds an option for restoring the removed enemies ACACIA and SHADMIRAGE for releases outside Japan.

Requires setting the new option `restored_enemy` in ps4.options.asm to 1.

Setting `revision` to 0 behaves the same as before regardless of whether the `restored_enemy` value is set to 0 or 1.

The new option is disabled by default.
